### PR TITLE
Add public method to get facade and get IPP Instance to Batch Sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "keywords": ["Laravel", "laravel-quickbooks"],
     "require": {
         "illuminate/support": "~5",
-        "quickbooks/v3-php-sdk": "^5.0.3"
+        "quickbooks/v3-php-sdk": "5.0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,8 @@ Then you have to define:
  * `quickBooksResource` - One of the QuickBooks resources classes (e.g.. `\LifeOnScreen\LaravelQuickBooks\Resources\Company::class`).
  * `getQuickBooksArray()` - This method must return the associative array which will be synced to QuickBooks.
  * `quickBooksIdColumn` (optional) - The column to use for storing the QuickBooks ID (defaults to `quickbooks_id`)
+ * `quickBooksSyncTokenColumn` (optional) - The column to use for storing the QuickBooks SyncToken (defaults to `sync_token`)
+ * `returnObject` (optional) - The property to define if INSERT and UPDATE Operation return the QuickBooks Object or a boolean (defaults to `false`)
 
 Usage example:
 

--- a/src/Facades/PaymentMethod.php
+++ b/src/Facades/PaymentMethod.php
@@ -1,0 +1,33 @@
+<?php
+namespace LifeOnScreen\LaravelQuickBooks\Facades;
+
+use QuickBooksOnline\API\Facades\FacadeHelper;
+
+/**
+ * Provisional Facade while is incorporated in QuickBooksOnline Package
+ * Class PaymentMethod
+ * @package LifeOnScreen\LaravelQuickBooks\Facades
+ */
+class PaymentMethod{
+
+    public static function create(array $data, $throwException = TRUE){
+        if(!isset($data) || empty($data)) throw new \Exception("Passed array for creating PaymentMethod is Empty");
+        $PaymentObject = FacadeHelper::reflectArrayToObject("PaymentMethod", $data, $throwException );
+        return $PaymentObject;
+    }
+
+    /**
+     * This is an immutable function
+     */
+    public static function update($objToUpdate, array $data){
+        $classOfObj = get_class($objToUpdate);
+        if(strcmp($classOfObj, FacadeHelper::simpleAppendClassNameSpace("PaymentMethod")) != 0){
+            throw new \Exception("Target object class:{" .  $classOfObj . "} is not an instance of PaymentMethod.");
+        }
+        $newPaymentObj = Payment::create($data);
+        $clonedOfObj = FacadeHelper::cloneObj($objToUpdate);
+        FacadeHelper::mergeObj($clonedOfObj, $newPaymentObj);
+        return $clonedOfObj;
+    }
+
+}

--- a/src/QuickBookable.php
+++ b/src/QuickBookable.php
@@ -6,7 +6,5 @@ interface QuickBookable
 {
     public function getQuickBooksIdAttribute();
 
-    public function getQuickBooksArray();
-
     public function syncToQuickbooks();
 }

--- a/src/QuickBooksAuthenticator.php
+++ b/src/QuickBooksAuthenticator.php
@@ -40,7 +40,7 @@ class QuickBooksAuthenticator
         $realmID = Request::get('realmId');
         $requestCode = Request::get('code');
 
-        if (empty($realmID) || empty($requestCode) || !self::cookieIsValid()) {
+        if (empty($realmID) || empty($requestCode) || !static::cookieIsValid()) {
             return false;
         }
 
@@ -94,7 +94,7 @@ class QuickBooksAuthenticator
      * Get QuickBooksOnline\API\DataService\DataService object.
      * @throws \QuickBooksOnline\API\Exception\SdkException
      */
-    protected static function getDataService(): DataService
+    protected static function getDataService()
     {
         return DataService::Configure([
             'auth_mode'    => config('quickbooks.data-service.auth-mode'),
@@ -135,12 +135,17 @@ class QuickBooksAuthenticator
         }
 
         try {
-            App::make(QuickBooksConnection::class);
+            static::getConnection();
             return true;
         }
         catch (Exception $e) {
             return false;
         }
+    }
+
+    protected static function getConnection()
+    {
+        return App::make('QuickBooksConnection');
     }
 
     /**

--- a/src/QuickBooksResource.php
+++ b/src/QuickBooksResource.php
@@ -48,17 +48,18 @@ class QuickBooksResource
             $this->name   = $resource['name'];
         }
 
-        $this->connection = App::make(QuickBooksConnection::class);
+        $this->connection = App::make('QuickBooksConnection');
     }
 
     /**
      * Create a resource
      *
      * @param array $attributes
+     * @param bool $returnObject This parameter manages if this method return An object or an Id
      * @return bool|int
      * @throws \QuickBooksOnline\API\Exception\IdsException
      */
-    public function create($attributes)
+    public function create($attributes, bool $returnObject = false)
     {
         $object = $this->getResourceFacade()::create($attributes);
 
@@ -66,16 +67,18 @@ class QuickBooksResource
             return false;
         }
 
-        return (int) $response->Id;
+        return $returnObject ? $response : (int) $response->Id;
     }
 
     /**
      * Update a resource.
-     *
-     * @param $where
+     * @param $id
      * @param $attributes
+     * @param bool $returnObject
+     * @return bool
+     * @throws \Exception
      */
-    public function update($id, $attributes)
+    public function update($id, $attributes, bool $returnObject = false)
     {
         $resource = $this->find($id);
 
@@ -89,7 +92,7 @@ class QuickBooksResource
             return false;
         }
 
-        return $response->Id;
+        return $returnObject ? $response : $response->Id;
     }
 
     /**
@@ -182,7 +185,7 @@ class QuickBooksResource
      *
      * @return string
      */
-    protected function getResourceFacade()
+    public function getResourceFacade()
     {
         return $this->facade;
     }
@@ -192,7 +195,7 @@ class QuickBooksResource
      *
      * @return string
      */
-    protected function getResourceName()
+    public function getResourceName()
     {
         return $this->name;
     }

--- a/src/QuickBooksResource.php
+++ b/src/QuickBooksResource.php
@@ -71,6 +71,22 @@ class QuickBooksResource
     }
 
     /**
+     * Method to Void a Resource
+     *
+     * @param $object
+     * @param bool $returnObject
+     * @return bool
+     */
+    public function void($object, bool $returnObject=false)
+    {
+        if (!$response = $this->request('Void', $object)) {
+            return false;
+        }
+
+        return $returnObject ? $response : $response->Id;
+    }
+
+    /**
      * Update a resource.
      * @param $id
      * @param $attributes

--- a/src/Resources/PaymentMethod.php
+++ b/src/Resources/PaymentMethod.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LifeOnScreen\LaravelQuickBooks\Resources;
+
+use LifeOnScreen\LaravelQuickBooks\QuickBooksResource;
+use LifeOnScreen\LaravelQuickBooks\Facades as QuickBooksFacades;
+
+class PaymentMethod extends QuickBooksResource
+{
+    /**
+     * The name of this resource.
+     *
+     * @var string
+     */
+    protected $name = 'PaymentMethod';
+
+    /**
+     * QuickBooks Online API Facade
+     *
+     * @var string
+     */
+    protected $facade = QuickBooksFacades\PaymentMethod::class;
+}

--- a/src/SyncsToQuickBooks.php
+++ b/src/SyncsToQuickBooks.php
@@ -10,6 +10,12 @@ trait SyncsToQuickBooks
     protected $quickBooksResourceInstance;
 
     /**
+     * This variable magane if each operation (Insert | Update) return an Object or an Id
+     * @var bool
+     */
+    protected static $returnObject = false;
+
+    /**
      * The data to sync to QuickBooks.
      *
      * @see https://developer.intuit.com/docs/api/accounting
@@ -18,19 +24,62 @@ trait SyncsToQuickBooks
     abstract protected function getQuickBooksArray(): array;
 
     /**
+     * Method to get QuickBooksAttributeIdName
+     * @return string
+     */
+    public function getQuickBooksAttributeIdName()
+    {
+        return $this->quickBooksIdColumn ?? 'quickbooks_id';
+    }
+
+    /**
+     * Method to get QuickBooksAttributeSyncTokenName
+     * @return string
+     */
+    public function getQuickBooksAttributeSyncTokenName()
+    {
+        return $this->quickBooksSyncTokenColumn ?? 'sync_token';
+    }
+
+    /**
      * Allows you to use `$model->quickbooks_id` regardless of the actual column being used.
      *
      * @return null|string
      */
     public function getQuickBooksIdAttribute(): ?string
     {
-        $quickBooksIdColumn = $this->quickBooksIdColumn ?? 'quickbooks_id';
+        if (isset($this->attributes[$this->getQuickBooksAttributeIdName()])) {
+            return $this->attributes[$this->getQuickBooksAttributeIdName()];
+        }
+        return null;
+    }
 
-        if (isset($this->attributes[$quickBooksIdColumn])) {
-            return $this->attributes[$quickBooksIdColumn];
+    /**
+     * Allows you to use `$model->sync_token` regardless of the actual column being used.
+     *
+     * @return null|int
+     */
+    public function getQuickBooksSyncTokenAttribute(): ?int
+    {
+        if (isset($this->attributes[$this->getQuickBooksAttributeSyncTokenName()])) {
+            return $this->attributes[$this->getQuickBooksAttributeSyncTokenName()];
+        }
+        return null;
+    }
+
+    /**
+     * Allows you to save `$model->quickbooks_id`.
+     * @param $value
+     * @return boolean
+     */
+    protected function saveQuickBooksIdAttribute($Id, $SyncToken): bool
+    {
+        $this->{$this->getQuickBooksAttributeIdName()} = $Id;
+        if(static::$returnObject && !is_null($SyncToken)) {
+            $this->{$this->getQuickBooksAttributeSyncTokenName()} = $SyncToken;
         }
 
-        return null;
+        return $this->save();
     }
 
     /**
@@ -43,52 +92,53 @@ trait SyncsToQuickBooks
 
     /**
      * Creates the model in QuickBooks.
-     *
-     * @return bool
-     * @throws \QuickBooksOnline\API\Exception\IdsException
+     * @return mixed
+     * @throws \Exception
      */
-    public function insertToQuickBooks(): bool
+    public function insertToQuickBooks()
     {
         $attributes = $this->getQuickBooksArray();
-        $resourceId = $this->getQuickBooksResourceInstance()->create($attributes);
+        $resource = $this->getQuickBooksResourceInstance()->create($attributes, static::$returnObject);
 
-        if (!$resourceId) {
+        if (!$resource) {
             return false;
         }
 
-        $this->quickbooks_id = $resourceId;
-        $this->save();
+        $this->saveQuickBooksIdAttribute($resource->Id, $resource->SyncToken);
 
-        return true;
+        return static::$returnObject && is_object($resource) ? $resource : true;
     }
 
     /**
      * Updates the model in QuickBooks.
      *
-     * @return bool
+     * @return mixed
      * @throws \QuickBooksOnline\API\Exception\IdsException
      * @throws \Exception
      */
-    public function updateToQuickBooks(): bool
+    public function updateToQuickBooks()
     {
-        if (empty($this->quickbooks_id)) {
+        if (empty($this->getQuickBooksIdAttribute())) {
             return false;
         }
 
         $attributes = $this->getQuickBooksArray();
+        $dataSync = $this->getQuickBooksResourceInstance()->update($this->getQuickBooksIdAttribute(), $attributes, static::$returnObject);
+        if($dataSync && static::$returnObject){
+            $this->saveQuickBooksIdAttribute($dataSync->Id, $dataSync->SyncToken);
+        }
 
-        return $this->getQuickBooksResourceInstance()->update($this->quickbooks_id, $attributes);
+        return $dataSync;
     }
 
     /**
-     * Syncs the model to QuickBooks.
-     *
-     * @return bool
-     * @throws \QuickBooksOnline\API\Exception\IdsException
+     * Syncs the model to QuickBooks
+     * @return bool|mixed
+     * @throws \Exception
      */
-    public function syncToQuickBooks(): bool
+    public function syncToQuickBooks()
     {
-        if (empty($this->quickbooks_id)) {
+        if (empty($this->getQuickBooksIdAttribute())) {
             return $this->insertToQuickBooks();
         }
 
@@ -123,5 +173,28 @@ trait SyncsToQuickBooks
         }
 
         return $this->quickBooksResourceInstance;
+    }
+
+    /**
+     * Method to get the Resource Name
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getResourceName()
+    {
+        return $this->getQuickBooksResourceInstance()->getResourceName();
+    }
+
+    /**
+     * Method to get an instance to a synchronize by Batch
+     * @param $data
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getQuickBooksInstanceToBatch(array $data = null)
+    {
+        $facade = $this->getQuickBooksResourceInstance()->getResourceFacade();
+        $object = $facade::create($data ?? $this->getQuickBooksArray());
+        return $object;
     }
 }


### PR DESCRIPTION
Hi guys, I'll describe the changes in this PR:

- **public function getResourceFacade()**:
This method actually is protected and I need to get the Facade for know the QuickBooks Resource name.

- Remove **public function getQuickBooksArray();**:
This method already is in the **SyncsToQuickBooks.php** Trait as an abstract protected method and this ambiguity generates an issue.

- Add **getResourceName** Method:
This method is required to know the Resource name from its Facade.

- Add **getQuickBooksInstanceToBatch** method:
This method returns a QuickBooks instance to synchronize by batch

- Update **quickbooks/v3-php-sdk** package to version 5.0.5:
This update solves the TLS 1.3 Compatibility and maintains TLS 1.2 compatibility

- Add **getQuickBooksSyncTokenAttribute** method:
This change adds the possibility of storing the QuickBooks SyncToken attribute in all entities after each operation (Insert | Update).

- Change self to static **static::cookieIsValid()**:
This change is to allow extend this class and override the Cookie Validation

- Add **PaymentMethod** Facade: 
This is a provisional Facade while is incorporated into Official QuickBooksOnline Package

- Add **PaymentMethod** Resource: 
This is the Payment Method Resource

- Remove method return type **getDataService(): DataService** QuickBooksAuthenticator file:
This change is to allow to override the **getDataService** method to extend the DataService class 

Tranks.