### PR TITLE
Hotfix for latest Laravel version

### DIFF
--- a/src/QuickBookable.php
+++ b/src/QuickBookable.php
@@ -6,7 +6,5 @@ interface QuickBookable
 {
     public function getQuickBooksIdAttribute();
 
-    public function getQuickBooksArray();
-
     public function syncToQuickbooks();
 }

--- a/src/QuickBooksEntity.php
+++ b/src/QuickBooksEntity.php
@@ -29,4 +29,9 @@ abstract class QuickBooksEntity extends Model implements QuickBookable
      * @var string
      */
     protected $quickBooksResource;
+    
+    /**
+     * @return array
+     */
+    public abstract function getQuickBooksArray() : array;
 }


### PR DESCRIPTION
On the latest Laravel version I have this probleme

Access level to LifeOnScreen\LaravelQuickBooks\QuickBooksEntity::getQuickBooksArray() must be public (as in class LifeOnScreen\LaravelQuickBooks\QuickBookable)

My fix resolve this :D